### PR TITLE
Adds error if pokemons' points sum more than 600

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -4,4 +4,3 @@ skips: B101,B311,B112
 # B101: assert
 # B311: random
 # B112: try-except-continue
-# B110: try_except_pass

--- a/.bandit
+++ b/.bandit
@@ -4,3 +4,4 @@ skips: B101,B311,B112
 # B101: assert
 # B311: random
 # B112: try-except-continue
+# B110: try_except_pass

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from pokemons.exceptions import PokemonNotFound
 from battles.models import Battle
 from pokemons.helpers import save_pokemon, get_pokemons_points_sum
 from pokemons.models import Pokemon
@@ -72,7 +73,7 @@ class BattleForm(forms.ModelForm):
             pokemon_points_sum = get_pokemons_points_sum(
                 [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
             )
-        except:  # noqa #nosec
+        except PokemonNotFound: # noqa #nosec
             pass
 
         if pokemon_points_sum > 600:

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -73,7 +73,7 @@ class BattleForm(forms.ModelForm):
             pokemon_points_sum = get_pokemons_points_sum(
                 [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
             )
-        except PokemonNotFound: # noqa #nosec
+        except PokemonNotFound:  # noqa #nosec
             pass
 
         if pokemon_points_sum > 600:

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -68,10 +68,12 @@ class BattleForm(forms.ModelForm):
         creator_pokemon_3_input = cleaned_data.get("creator_pokemon_3_input")
 
         pokemon_points_sum = 0
-        if self.is_valid():
+        try:
             pokemon_points_sum = get_pokemons_points_sum(
                 [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
             )
+        except:  # noqa
+            pass
 
         if pokemon_points_sum > 600:
             raise forms.ValidationError("Pokemons' points sum cannot be more than 600")

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 
-from pokemons.exceptions import PokemonNotFound
 from battles.models import Battle
+from pokemons.exceptions import PokemonNotFound
 from pokemons.helpers import save_pokemon, get_pokemons_points_sum
 from pokemons.models import Pokemon
 from pokemons.services import pokemon_exists

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 
 from battles.models import Battle
-from pokemons.helpers import save_pokemon
+from pokemons.helpers import save_pokemon, get_pokemons_points_sum
 from pokemons.models import Pokemon
 from pokemons.services import pokemon_exists
 from users.models import User
@@ -41,32 +41,51 @@ class BattleForm(forms.ModelForm):
         self.fields["opponent"].queryset = User.objects.exclude(email=self.current_user.email)
         self.fields["creator"].initial = self.current_user
 
-    def clean_creator_pokemon_1(self):
+    def clean_creator_pokemon_1_input(self):
         data = self.cleaned_data.get("creator_pokemon_1_input")
         if not pokemon_exists(data):
             self.add_error("creator_pokemon_1_input", "Sorry, this pokemon was not found")
-            return None
-        pokemon = save_pokemon(data)
-        return pokemon
+        return data
 
-    def clean_creator_pokemon_2(self):
+    def clean_creator_pokemon_2_input(self):
         data = self.cleaned_data.get("creator_pokemon_2_input")
         if not pokemon_exists(data):
             self.add_error("creator_pokemon_2_input", "Sorry, this pokemon was not found")
-            return None
-        pokemon = save_pokemon(data)
-        return pokemon
+        return data
 
-    def clean_creator_pokemon_3(self):
+    def clean_creator_pokemon_3_input(self):
         data = self.cleaned_data.get("creator_pokemon_3_input")
         if not pokemon_exists(data):
             self.add_error("creator_pokemon_3_input", "Sorry, this pokemon was not found")
-            return None
-        pokemon = save_pokemon(data)
-        return pokemon
+        return data
 
     def clean(self):
         cleaned_data = super().clean()
         cleaned_data["creator"] = self.fields["creator"].initial
 
+        creator_pokemon_1_input = cleaned_data.get("creator_pokemon_1_input")
+        creator_pokemon_2_input = cleaned_data.get("creator_pokemon_2_input")
+        creator_pokemon_3_input = cleaned_data.get("creator_pokemon_3_input")
+
+        pokemon_points_sum = 0
+        if self.is_valid():
+            pokemon_points_sum = get_pokemons_points_sum(
+                [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
+            )
+
+        if pokemon_points_sum > 600:
+            raise forms.ValidationError("Pokemons' points sum cannot be more than 600")
+
         return cleaned_data
+
+    def save(self, commit=True):
+        self.instance.creator_pokemon_1 = save_pokemon(
+            self.cleaned_data.get("creator_pokemon_1_input")
+        )
+        self.instance.creator_pokemon_2 = save_pokemon(
+            self.cleaned_data.get("creator_pokemon_2_input")
+        )
+        self.instance.creator_pokemon_3 = save_pokemon(
+            self.cleaned_data.get("creator_pokemon_3_input")
+        )
+        return super(BattleForm, self).save(commit)

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -72,7 +72,7 @@ class BattleForm(forms.ModelForm):
             pokemon_points_sum = get_pokemons_points_sum(
                 [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
             )
-        except:  # noqa
+        except:  # noqa #nosec
             pass
 
         if pokemon_points_sum > 600:

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -73,7 +73,7 @@ class BattleForm(forms.ModelForm):
             pokemon_points_sum = get_pokemons_points_sum(
                 [creator_pokemon_1_input, creator_pokemon_2_input, creator_pokemon_3_input]
             )
-        except PokemonNotFound:  # noqa #nosec
+        except PokemonNotFound:
             pass
 
         if pokemon_points_sum > 600:

--- a/backend/battles/templates/battles/battle_form.html
+++ b/backend/battles/templates/battles/battle_form.html
@@ -6,7 +6,7 @@
 <h1>Create a new Pokebattle</h1>
 <form id="battle-form" action="{% url 'battles:battle_create' %}" method="post">
     {% csrf_token %}
-  {{ form.non_field_errors }}
+  <span class="field-error">{{ form.non_field_errors }}</span>
   <div class="field-wrapper">
     <label for="{{ form.opponent.id_for_label }}">Opponent:</label>
     {{ form.opponent }}

--- a/backend/pokemons/exceptions.py
+++ b/backend/pokemons/exceptions.py
@@ -1,0 +1,6 @@
+class PokemonNotFound(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return "{} was not found in PokeAPI".format(self.value)

--- a/backend/pokemons/exceptions.py
+++ b/backend/pokemons/exceptions.py
@@ -1,5 +1,6 @@
 class PokemonNotFound(Exception):
     def __init__(self, value):
+        super().__init__()
         self.value = value
 
     def __str__(self):

--- a/backend/pokemons/helpers.py
+++ b/backend/pokemons/helpers.py
@@ -18,3 +18,21 @@ def save_pokemon(poke_id):
     )
 
     return pokemon
+
+
+def get_pokemons_points_sum(poke_ids):
+    points_sum = 0
+    for poke_id in poke_ids:
+        pokemon = Pokemon.objects.filter(poke_id=poke_id).first()
+
+        if pokemon:
+            points_sum += pokemon.attack + pokemon.defense + pokemon.hit_points
+        else:
+            pokemon = get_pokemon(poke_id)
+            points_sum += (
+                pokemon["stats"][1]["base_stat"]
+                + pokemon["stats"][2]["base_stat"]
+                + pokemon["stats"][0]["base_stat"]
+            )
+
+    return points_sum

--- a/backend/pokemons/helpers.py
+++ b/backend/pokemons/helpers.py
@@ -1,5 +1,6 @@
+from pokemons.exceptions import PokemonNotFound
 from pokemons.models import Pokemon
-from pokemons.services import get_pokemon
+from pokemons.services import get_pokemon, pokemon_exists
 
 
 def save_pokemon(poke_id):
@@ -28,6 +29,8 @@ def get_pokemons_points_sum(poke_ids):
         if pokemon:
             points_sum += pokemon.attack + pokemon.defense + pokemon.hit_points
         else:
+            if not pokemon_exists(poke_id):
+                raise PokemonNotFound(poke_id)
             pokemon = get_pokemon(poke_id)
             points_sum += (
                 pokemon["stats"][1]["base_stat"]

--- a/backend/pokemons/models.py
+++ b/backend/pokemons/models.py
@@ -7,3 +7,6 @@ class Pokemon(models.Model):
     attack = models.IntegerField()
     defense = models.IntegerField()
     hit_points = models.IntegerField()
+
+    def __str__(self):
+        return self.name

--- a/backend/pokemons/tests.py
+++ b/backend/pokemons/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/backend/pokemons/tests/test_helpers.py
+++ b/backend/pokemons/tests/test_helpers.py
@@ -1,0 +1,26 @@
+import responses
+from django.test import TestCase
+from model_mommy import mommy
+
+from common.constants import POKEAPI_BASE_URL
+from pokemons.exceptions import PokemonNotFound
+from pokemons.helpers import get_pokemons_points_sum
+
+
+class PokemonHelperTests(TestCase):
+    @responses.activate
+    def test_raises_exception_if_pokemon_does_not_exist_when_calculating_points_sum(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/0", status=404)
+
+        responses.add(
+            responses.GET,
+            f"{POKEAPI_BASE_URL}pokemon/0",
+            status=404,
+            json={"error": "not found"},
+        )
+
+        mommy.make("pokemons.Pokemon", poke_id=1)
+        mommy.make("pokemons.Pokemon", poke_id=2)
+
+        with self.assertRaises(PokemonNotFound):
+            get_pokemons_points_sum([0, 1, 2])


### PR DESCRIPTION
[As a Trainer I see form errors in case the PKNs I select sum more than 600 points](https://trello.com/c/3lauyxqC/17-as-a-trainer-i-see-form-errors-in-case-the-pkns-i-select-sum-more-than-600-points)

### Description
This PR adds error if points of selected Pokemons sum more than 600.

### How to test
- [ ] Click to add a battle
- [ ] Select your opponent
- [ ] Fill the Pokemons with the following ids: 493 (Arceus), 646 (Kyurem), and 150 (Mewtwo).
- [ ] Check that you cannot create a battle if the points sum more than 600