### PR TITLE
Adds page to see ongoing battles

### DIFF
--- a/backend/battles/models.py
+++ b/backend/battles/models.py
@@ -14,6 +14,13 @@ class BattleQuerySet(models.QuerySet):
             opponent_pokemon_3__isnull=False,
         )
 
+    def ongoing(self):
+        return self.filter(
+            opponent_pokemon_1__isnull=True,
+            opponent_pokemon_2__isnull=True,
+            opponent_pokemon_3__isnull=True,
+        )
+
 
 class Battle(models.Model):
     creator = models.ForeignKey(

--- a/backend/battles/static/css/styles.css
+++ b/backend/battles/static/css/styles.css
@@ -3,6 +3,15 @@
     margin-top: 16px;
 }
 
+.navigation {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.navigation a {
+    margin-left: 24px;
+}
+
 /* Battles list styles */
 #battles-list {
     list-style: none;

--- a/backend/battles/templates/battles/battle_list.html
+++ b/backend/battles/templates/battles/battle_list.html
@@ -4,6 +4,11 @@
 <link rel="stylesheet" type="text/css" href="{% static 'css/global.css' %}" />
 
 <h1>Battles</h1>
+<nav class="navigation">
+  <a class="nav-link" href="{% url 'battles:battle_create' %}">Add new</a>
+  <a class="nav-link" href="{% url 'battles:settled_battles_list' %}">Settled</a>
+  <a class="nav-link" href="{% url 'battles:ongoing_battles_list' %}">Ongoing</a>
+</nav>
 <ul id="battles-list">
   {% for battle in object_list %}
   <li><a href="{% url 'battles:battle_detail' battle.id %}">Pokebattle {{ battle.id }}</a></li>
@@ -11,4 +16,3 @@
     <li>No battles yet.</li>
   {% endfor %}
 </ul>
-<a class="nav-link" href="{% url 'battles:battle_create' %}">Add new</a>

--- a/backend/battles/templates/battles/battle_ongoing_list.html
+++ b/backend/battles/templates/battles/battle_ongoing_list.html
@@ -1,0 +1,14 @@
+{% load static %}
+
+<link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}" />
+<link rel="stylesheet" type="text/css" href="{% static 'css/global.css' %}" />
+
+<h1>Battles</h1>
+<ul id="battles-list">
+  {% for battle in object_list %}
+  <li><a href="{% url 'battles:battle_detail' battle.id %}">Pokebattle {{ battle.id }}</a></li>
+  {% empty %}
+    <li>No battles yet.</li>
+  {% endfor %}
+</ul>
+<a class="nav-link" href="{% url 'battles:battle_list' %}">Back to all battles</a>

--- a/backend/battles/templates/battles/battle_settled_list.html
+++ b/backend/battles/templates/battles/battle_settled_list.html
@@ -1,0 +1,14 @@
+{% load static %}
+
+<link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}" />
+<link rel="stylesheet" type="text/css" href="{% static 'css/global.css' %}" />
+
+<h1>Battles</h1>
+<ul id="battles-list">
+  {% for battle in object_list %}
+  <li><a href="{% url 'battles:battle_detail' battle.id %}">Pokebattle {{ battle.id }}</a></li>
+  {% empty %}
+    <li>No battles yet.</li>
+  {% endfor %}
+</ul>
+<a class="nav-link" href="{% url 'battles:battle_list' %}">Back too all battles</a>

--- a/backend/battles/tests/test_models.py
+++ b/backend/battles/tests/test_models.py
@@ -5,7 +5,6 @@ from battles.models import Battle
 
 
 class BattleQuerySetTests(TestCase):
-
     def test_get_settled_battles(self):
         creator = mommy.make("users.User")
         opponent = mommy.make("users.User")

--- a/backend/battles/tests/test_models.py
+++ b/backend/battles/tests/test_models.py
@@ -5,6 +5,7 @@ from battles.models import Battle
 
 
 class BattleQuerySetTests(TestCase):
+
     def test_get_settled_battles(self):
         creator = mommy.make("users.User")
         opponent = mommy.make("users.User")
@@ -37,3 +38,36 @@ class BattleQuerySetTests(TestCase):
         battles = Battle.objects.settled()
         self.assertIn(battle_2, battles)
         self.assertNotIn(battle_1, battles)
+
+    def test_get_ongoing_battles(self):
+        creator = mommy.make("users.User")
+        opponent = mommy.make("users.User")
+
+        pokemon_1 = mommy.make("pokemons.Pokemon")
+        pokemon_2 = mommy.make("pokemons.Pokemon")
+        pokemon_3 = mommy.make("pokemons.Pokemon")
+
+        battle_1 = mommy.make(
+            "battles.Battle",
+            creator=creator,
+            opponent=opponent,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        battle_2 = mommy.make(
+            "battles.Battle",
+            creator=creator,
+            opponent=opponent,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+            opponent_pokemon_1=pokemon_3,
+            opponent_pokemon_2=pokemon_2,
+            opponent_pokemon_3=pokemon_1,
+        )
+
+        battles = Battle.objects.ongoing()
+        self.assertIn(battle_1, battles)
+        self.assertNotIn(battle_2, battles)

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -295,3 +295,46 @@ class SettledBattlesListViewTests(TestCase):
         battles = response.context_data["object_list"]
         self.assertIn(battle_2, battles)
         self.assertNotIn(battle_1, battles)
+
+
+class OngoingBattlesListViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_list_settled_battles(self):
+        creator = mommy.make("users.User")
+        opponent = mommy.make("users.User")
+
+        pokemon_1 = mommy.make("pokemons.Pokemon")
+        pokemon_2 = mommy.make("pokemons.Pokemon")
+        pokemon_3 = mommy.make("pokemons.Pokemon")
+
+        battle_1 = mommy.make(
+            "battles.Battle",
+            creator=creator,
+            opponent=opponent,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        battle_2 = mommy.make(
+            "battles.Battle",
+            creator=creator,
+            opponent=opponent,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+            opponent_pokemon_1=pokemon_3,
+            opponent_pokemon_2=pokemon_2,
+            opponent_pokemon_3=pokemon_1,
+        )
+
+        url = reverse("battles:ongoing_battles_list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        battles = response.context_data["object_list"]
+        self.assertIn(battle_1, battles)
+        self.assertNotIn(battle_2, battles)

--- a/backend/battles/urls.py
+++ b/backend/battles/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
         name="battle_update_opponent_pokemons",
     ),
     path("settled", views.SettledBattlesList.as_view(), name="settled_battles_list"),
+    path("ongoing", views.OngoingBattlesList.as_view(), name="ongoing_battles_list"),
 ]

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -45,3 +45,10 @@ class SettledBattlesList(ListView):
 
     def get_queryset(self):
         return Battle.objects.settled()
+
+
+class OngoingBattlesList(ListView):
+    model = Battle
+
+    def get_queryset(self):
+        return Battle.objects.ongoing()

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -42,6 +42,7 @@ class BattleList(ListView):
 
 class SettledBattlesList(ListView):
     model = Battle
+    template_name = "battles/battle_settled_list.html"
 
     def get_queryset(self):
         return Battle.objects.settled()
@@ -49,6 +50,7 @@ class SettledBattlesList(ListView):
 
 class OngoingBattlesList(ListView):
     model = Battle
+    template_name = "battles/battle_ongoing_list.html"
 
     def get_queryset(self):
         return Battle.objects.ongoing()


### PR DESCRIPTION
[As a Trainer I see a list of on going battles](https://trello.com/c/7q18wYIy/8-as-a-trainer-i-see-a-list-of-on-going-battles)

### Description
This PR adds a page with a list of ongoing battles. Also, it adds a link to these pages on the page that lists all battles.

### How to test
- [ ] Create a battle only with the creator's pokemons and another with creator's and opponent's pokemons.
- [ ] Access `localhost:8000/ongoing` and check that only the battle with creator's pokemons is appearing.