### PR TITLE
[Partial] Adds feature to creator choose Pokemons position

### DIFF
--- a/backend/battles/exceptions.py
+++ b/backend/battles/exceptions.py
@@ -1,0 +1,6 @@
+class DuplicatedPokemonPositions(Exception):
+    def __init__(self):
+        super().__init__()
+
+    def __str__(self):
+        return "Pokemon positions are duplicated"

--- a/backend/battles/exceptions.py
+++ b/backend/battles/exceptions.py
@@ -1,6 +1,3 @@
 class DuplicatedPokemonPositions(Exception):
-    def __init__(self):
-        super().__init__()
-
     def __str__(self):
         return "Pokemon positions are duplicated"

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -109,7 +109,11 @@ class BattleForm(forms.ModelForm):
         try:
             position_pokemons(
                 [creator_pokemon_1, creator_pokemon_2, creator_pokemon_3],
-                [position_creator_pokemon_1, position_creator_pokemon_2, position_creator_pokemon_3]
+                [
+                    position_creator_pokemon_1,
+                    position_creator_pokemon_2,
+                    position_creator_pokemon_3,
+                ],
             )
         except DuplicatedPokemonPositions:
             raise forms.ValidationError("Please add each Pokemon in a different position")
@@ -127,7 +131,7 @@ class BattleForm(forms.ModelForm):
 
         positioned_pokemons = position_pokemons(
             [creator_pokemon_1, creator_pokemon_2, creator_pokemon_3],
-            [position_creator_pokemon_1, position_creator_pokemon_2, position_creator_pokemon_3]
+            [position_creator_pokemon_1, position_creator_pokemon_2, position_creator_pokemon_3],
         )
 
         self.instance.creator_pokemon_1 = positioned_pokemons[0]

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -158,25 +158,12 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         widget=autocomplete.ModelSelect2(url="pokemons:pokemon_autocomplete"),
     )
 
-    position_opponent_pokemon_1 = forms.ChoiceField(
-        choices=POKEMON_POSITION_CHOICES, initial=1, required=False
-    )
-    position_opponent_pokemon_2 = forms.ChoiceField(
-        choices=POKEMON_POSITION_CHOICES, initial=2, required=False
-    )
-    position_opponent_pokemon_3 = forms.ChoiceField(
-        choices=POKEMON_POSITION_CHOICES, initial=3, required=False
-    )
-
     class Meta:
         model = Battle
         fields = [
             "opponent_pokemon_1",
             "opponent_pokemon_2",
             "opponent_pokemon_3",
-            "position_opponent_pokemon_1",
-            "position_opponent_pokemon_2",
-            "position_opponent_pokemon_3",
         ]
 
     def clean_opponent_pokemon_1(self):
@@ -204,10 +191,6 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         opponent_pokemon_2 = cleaned_data.get("opponent_pokemon_2")
         opponent_pokemon_3 = cleaned_data.get("opponent_pokemon_3")
 
-        position_opponent_pokemon_1 = cleaned_data.get("position_opponent_pokemon_1")
-        position_opponent_pokemon_2 = cleaned_data.get("position_opponent_pokemon_2")
-        position_opponent_pokemon_3 = cleaned_data.get("position_opponent_pokemon_3")
-
         pokemon_points_sum = 0
         try:
             pokemon_points_sum = get_pokemons_points_sum(
@@ -219,41 +202,4 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         if pokemon_points_sum > 600:
             raise forms.ValidationError("Pokemons' points sum cannot be more than 600")
 
-        # The exception treatment needs to be in clean method, so it can show the Validation Error in the form
-        try:
-            position_pokemons(
-                opponent_pokemon_1,
-                opponent_pokemon_2,
-                opponent_pokemon_3,
-                position_opponent_pokemon_1,
-                position_opponent_pokemon_2,
-                position_opponent_pokemon_3,
-            )
-        except DuplicatedPokemonPositions:
-            raise forms.ValidationError("Please add each Pokemon in a different position")
-
         return cleaned_data
-
-    def save(self, commit=True):
-        opponent_pokemon_1 = self.cleaned_data.get("opponent_pokemon_1")
-        opponent_pokemon_2 = self.cleaned_data.get("opponent_pokemon_2")
-        opponent_pokemon_3 = self.cleaned_data.get("opponent_pokemon_3")
-
-        position_opponent_pokemon_1 = self.cleaned_data.get("position_opponent_pokemon_1")
-        position_opponent_pokemon_2 = self.cleaned_data.get("position_opponent_pokemon_2")
-        position_opponent_pokemon_3 = self.cleaned_data.get("position_opponent_pokemon_3")
-
-        positioned_pokemons = position_pokemons(
-            opponent_pokemon_1,
-            opponent_pokemon_2,
-            opponent_pokemon_3,
-            position_opponent_pokemon_1,
-            position_opponent_pokemon_2,
-            position_opponent_pokemon_3,
-        )
-
-        self.instance.opponent_pokemon_1 = positioned_pokemons[0]
-        self.instance.opponent_pokemon_2 = positioned_pokemons[1]
-        self.instance.opponent_pokemon_3 = positioned_pokemons[2]
-
-        return super(BattleOpponentPokemonsForm, self).save(commit)

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -108,12 +108,8 @@ class BattleForm(forms.ModelForm):
         # so it can show the Validation Error in the form
         try:
             position_pokemons(
-                creator_pokemon_1,
-                creator_pokemon_2,
-                creator_pokemon_3,
-                position_creator_pokemon_1,
-                position_creator_pokemon_2,
-                position_creator_pokemon_3,
+                [creator_pokemon_1, creator_pokemon_2, creator_pokemon_3],
+                [position_creator_pokemon_1, position_creator_pokemon_2, position_creator_pokemon_3]
             )
         except DuplicatedPokemonPositions:
             raise forms.ValidationError("Please add each Pokemon in a different position")
@@ -130,12 +126,8 @@ class BattleForm(forms.ModelForm):
         position_creator_pokemon_3 = self.cleaned_data.get("position_creator_pokemon_3")
 
         positioned_pokemons = position_pokemons(
-            creator_pokemon_1,
-            creator_pokemon_2,
-            creator_pokemon_3,
-            position_creator_pokemon_1,
-            position_creator_pokemon_2,
-            position_creator_pokemon_3,
+            [creator_pokemon_1, creator_pokemon_2, creator_pokemon_3],
+            [position_creator_pokemon_1, position_creator_pokemon_2, position_creator_pokemon_3]
         )
 
         self.instance.creator_pokemon_1 = positioned_pokemons[0]

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -104,7 +104,8 @@ class BattleForm(forms.ModelForm):
         if pokemon_points_sum > 600:
             raise forms.ValidationError("Pokemons' points sum cannot be more than 600")
 
-        # The exception treatment needs to be in clean method, so it can show the Validation Error in the form
+        # The exception treatment needs to be in clean method,
+        # so it can show the Validation Error in the form
         try:
             position_pokemons(
                 creator_pokemon_1,

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -158,12 +158,25 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         widget=autocomplete.ModelSelect2(url="pokemons:pokemon_autocomplete"),
     )
 
+    position_opponent_pokemon_1 = forms.ChoiceField(
+        choices=POKEMON_POSITION_CHOICES, initial=1, required=False
+    )
+    position_opponent_pokemon_2 = forms.ChoiceField(
+        choices=POKEMON_POSITION_CHOICES, initial=2, required=False
+    )
+    position_opponent_pokemon_3 = forms.ChoiceField(
+        choices=POKEMON_POSITION_CHOICES, initial=3, required=False
+    )
+
     class Meta:
         model = Battle
         fields = [
             "opponent_pokemon_1",
             "opponent_pokemon_2",
             "opponent_pokemon_3",
+            "position_opponent_pokemon_1",
+            "position_opponent_pokemon_2",
+            "position_opponent_pokemon_3",
         ]
 
     def clean_opponent_pokemon_1(self):
@@ -191,6 +204,10 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         opponent_pokemon_2 = cleaned_data.get("opponent_pokemon_2")
         opponent_pokemon_3 = cleaned_data.get("opponent_pokemon_3")
 
+        position_opponent_pokemon_1 = cleaned_data.get("position_opponent_pokemon_1")
+        position_opponent_pokemon_2 = cleaned_data.get("position_opponent_pokemon_2")
+        position_opponent_pokemon_3 = cleaned_data.get("position_opponent_pokemon_3")
+
         pokemon_points_sum = 0
         try:
             pokemon_points_sum = get_pokemons_points_sum(
@@ -202,4 +219,41 @@ class BattleOpponentPokemonsForm(forms.ModelForm):
         if pokemon_points_sum > 600:
             raise forms.ValidationError("Pokemons' points sum cannot be more than 600")
 
+        # The exception treatment needs to be in clean method, so it can show the Validation Error in the form
+        try:
+            position_pokemons(
+                opponent_pokemon_1,
+                opponent_pokemon_2,
+                opponent_pokemon_3,
+                position_opponent_pokemon_1,
+                position_opponent_pokemon_2,
+                position_opponent_pokemon_3,
+            )
+        except DuplicatedPokemonPositions:
+            raise forms.ValidationError("Please add each Pokemon in a different position")
+
         return cleaned_data
+
+    def save(self, commit=True):
+        opponent_pokemon_1 = self.cleaned_data.get("opponent_pokemon_1")
+        opponent_pokemon_2 = self.cleaned_data.get("opponent_pokemon_2")
+        opponent_pokemon_3 = self.cleaned_data.get("opponent_pokemon_3")
+
+        position_opponent_pokemon_1 = self.cleaned_data.get("position_opponent_pokemon_1")
+        position_opponent_pokemon_2 = self.cleaned_data.get("position_opponent_pokemon_2")
+        position_opponent_pokemon_3 = self.cleaned_data.get("position_opponent_pokemon_3")
+
+        positioned_pokemons = position_pokemons(
+            opponent_pokemon_1,
+            opponent_pokemon_2,
+            opponent_pokemon_3,
+            position_opponent_pokemon_1,
+            position_opponent_pokemon_2,
+            position_opponent_pokemon_3,
+        )
+
+        self.instance.opponent_pokemon_1 = positioned_pokemons[0]
+        self.instance.opponent_pokemon_2 = positioned_pokemons[1]
+        self.instance.opponent_pokemon_3 = positioned_pokemons[2]
+
+        return super(BattleOpponentPokemonsForm, self).save(commit)

--- a/backend/battles/helpers.py
+++ b/backend/battles/helpers.py
@@ -1,6 +1,8 @@
 from decouple import config  # noqa
 from templated_email import send_templated_mail
 
+from battles.exceptions import DuplicatedPokemonPositions
+
 
 def compare_pokemons(pokemon_1, pokemon_2):
     pokemon_1_victory_points = 0
@@ -70,3 +72,18 @@ def send_battle_result(battle):
             "battle_opponent_pokemon_3": battle.opponent_pokemon_3.name,
         },
     )
+
+
+def position_pokemons(
+    pokemon_1, pokemon_2, pokemon_3, position_pokemon_1, position_pokemon_2, position_pokemon_3
+):
+    position_list = [position_pokemon_1, position_pokemon_2, position_pokemon_3]
+    if len(position_list) != len(set(position_list)):
+        raise DuplicatedPokemonPositions()
+
+    positioned_pokemons = []
+    positioned_pokemons.insert(position_pokemon_1 - 1, pokemon_1)
+    positioned_pokemons.insert(position_pokemon_2 - 1, pokemon_2)
+    positioned_pokemons.insert(position_pokemon_3 - 1, pokemon_3)
+
+    return positioned_pokemons

--- a/backend/battles/helpers.py
+++ b/backend/battles/helpers.py
@@ -79,11 +79,11 @@ def position_pokemons(
 ):
     position_list = [position_pokemon_1, position_pokemon_2, position_pokemon_3]
     if len(position_list) != len(set(position_list)):
-        raise DuplicatedPokemonPositions()
+        raise DuplicatedPokemonPositions
 
     positioned_pokemons = []
-    positioned_pokemons.insert(position_pokemon_1 - 1, pokemon_1)
-    positioned_pokemons.insert(position_pokemon_2 - 1, pokemon_2)
-    positioned_pokemons.insert(position_pokemon_3 - 1, pokemon_3)
+    positioned_pokemons.insert(int(position_pokemon_1) - 1, pokemon_1)
+    positioned_pokemons.insert(int(position_pokemon_2) - 1, pokemon_2)
+    positioned_pokemons.insert(int(position_pokemon_3) - 1, pokemon_3)
 
     return positioned_pokemons

--- a/backend/battles/helpers.py
+++ b/backend/battles/helpers.py
@@ -74,9 +74,15 @@ def send_battle_result(battle):
     )
 
 
-def position_pokemons(
-    pokemon_1, pokemon_2, pokemon_3, position_pokemon_1, position_pokemon_2, position_pokemon_3
-):
+def position_pokemons(pokemons, positions):
+    pokemon_1 = pokemons[0]
+    pokemon_2 = pokemons[1]
+    pokemon_3 = pokemons[2]
+
+    position_pokemon_1 = positions[0]
+    position_pokemon_2 = positions[1]
+    position_pokemon_3 = positions[2]
+
     position_list = [position_pokemon_1, position_pokemon_2, position_pokemon_3]
     if len(position_list) != len(set(position_list)):
         raise DuplicatedPokemonPositions

--- a/backend/battles/templates/battles/battle_form.html
+++ b/backend/battles/templates/battles/battle_form.html
@@ -27,6 +27,21 @@
     {{ form.creator_pokemon_3 }}
     <span class="field-error">{{ form.creator_pokemon_3.errors }}</span>
   </div>
+  <div class="field-wrapper">
+    <label for="{{ form.position_creator_pokemon_1.id_for_label }}">Pokemon 1 position:</label>
+    {{ form.position_creator_pokemon_1 }}
+    <span class="field-error">{{ form.position_creator_pokemon_1.errors }}</span>
+  </div>
+  <div class="field-wrapper">
+    <label for="{{ form.position_creator_pokemon_2.id_for_label }}">Pokemon 2 position:</label>
+    {{ form.position_creator_pokemon_2 }}
+    <span class="field-error">{{ form.position_creator_pokemon_2.errors }}</span>
+  </div>
+  <div class="field-wrapper">
+    <label for="{{ form.position_creator_pokemon_3.id_for_label }}">Pokemon 3 position:</label>
+    {{ form.position_creator_pokemon_3 }}
+    <span class="field-error">{{ form.position_creator_pokemon_3.errors }}</span>
+  </div>
   <button type="submit">Create Battle</button>
 </form>
 <a class="nav-link" href="{% url 'battles:battle_list' %}">Back to list</a>

--- a/backend/battles/tests/test_forms.py
+++ b/backend/battles/tests/test_forms.py
@@ -54,9 +54,13 @@ class BattleCreateFormTests(TestCase):
             "creator_pokemon_1": pokemon_1.id,
             "creator_pokemon_2": pokemon_2.id,
             "creator_pokemon_3": pokemon_3.id,
+            "position_creator_pokemon_1": "1",
+            "position_creator_pokemon_2": "2",
+            "position_creator_pokemon_3": "3",
         }
 
         form = BattleForm(data=data, current_user=current_user)
+        print(form.errors)
         self.assertTrue(form.is_valid())
 
         battle = form.save()
@@ -110,6 +114,9 @@ class BattleCreateFormTests(TestCase):
             "creator_pokemon_1": pokemon_1.id,
             "creator_pokemon_2": pokemon_2.id,
             "creator_pokemon_3": pokemon_3.id,
+            "position_creator_pokemon_1": "1",
+            "position_creator_pokemon_2": "2",
+            "position_creator_pokemon_3": "3",
         }
 
         form = BattleForm(data=data, current_user=current_user)
@@ -164,6 +171,9 @@ class BattleCreateFormTests(TestCase):
             "creator_pokemon_1": pokemon_1.id,
             "creator_pokemon_2": pokemon_2.id,
             "creator_pokemon_3": pokemon_3.id,
+            "position_creator_pokemon_1": "1",
+            "position_creator_pokemon_2": "2",
+            "position_creator_pokemon_3": "3",
         }
 
         form = BattleForm(data=data, current_user=current_user)
@@ -223,6 +233,66 @@ class BattleCreateFormTests(TestCase):
         self.assertFalse(form.is_valid())
 
         self.assertEqual(["Pokemons' points sum cannot be more than 600"], form.errors["__all__"])
+
+    @responses.activate
+    def test_choose_pokemon_position(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon1", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon2", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon3", status=200)
+
+        pokemon_1 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=1,
+            name="pokemon1",
+            attack=49,
+            defense=49,
+            hit_points=45,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/1.png",
+        )
+        pokemon_2 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=2,
+            name="pokemon2",
+            attack=64,
+            defense=64,
+            hit_points=50,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/2.png",
+        )
+        pokemon_3 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=3,
+            name="pokemon3",
+            attack=69,
+            defense=69,
+            hit_points=55,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/3.png",
+        )
+
+        current_user = mommy.make("users.User")
+        opponent = mommy.make("users.User", email="opponent@test.com")
+
+        data = {
+            "opponent": opponent.id,
+            "creator_pokemon_1": pokemon_1.id,
+            "creator_pokemon_2": pokemon_2.id,
+            "creator_pokemon_3": pokemon_3.id,
+            "position_creator_pokemon_1": "3",
+            "position_creator_pokemon_2": "1",
+            "position_creator_pokemon_3": "2",
+        }
+
+        form = BattleForm(data=data, current_user=current_user)
+        print(form.errors)
+
+        self.assertTrue(form.is_valid())
+
+        battle = form.save()
+        self.assertEqual(battle.creator_pokemon_1, pokemon_2)
+        self.assertEqual(battle.creator_pokemon_2, pokemon_3)
+        self.assertEqual(battle.creator_pokemon_3, pokemon_1)
 
 
 class BattleOpponentPokemonsFormTests(TestCase):

--- a/backend/battles/tests/test_forms.py
+++ b/backend/battles/tests/test_forms.py
@@ -285,6 +285,8 @@ class BattleCreateFormTests(TestCase):
         }
 
         form = BattleForm(data=data, current_user=current_user)
+        print(form.errors)
+
         self.assertTrue(form.is_valid())
 
         battle = form.save()

--- a/backend/battles/tests/test_forms.py
+++ b/backend/battles/tests/test_forms.py
@@ -285,8 +285,6 @@ class BattleCreateFormTests(TestCase):
         }
 
         form = BattleForm(data=data, current_user=current_user)
-        print(form.errors)
-
         self.assertTrue(form.is_valid())
 
         battle = form.save()

--- a/backend/battles/tests/test_helpers.py
+++ b/backend/battles/tests/test_helpers.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from model_mommy import mommy
 
-from battles.helpers import get_battle_result
+from battles.exceptions import DuplicatedPokemonPositions
+from battles.helpers import get_battle_result, position_pokemons
 
 
 class BattleHelperTests(TestCase):
@@ -114,3 +115,42 @@ class BattleHelperTests(TestCase):
 
         with self.assertRaises(Exception):
             get_battle_result(battle)
+
+    def test_position_pokemons(self):
+        pokemon_1 = mommy.make("pokemons.Pokemon", name="pokemon1")
+        pokemon_2 = mommy.make("pokemons.Pokemon", name="pokemon2")
+        pokemon_3 = mommy.make("pokemons.Pokemon", name="pokemon3")
+
+        position_pokemon_1 = 3
+        position_pokemon_2 = 1
+        position_pokemon_3 = 2
+
+        positioned_pokemons = position_pokemons(
+            pokemon_1,
+            pokemon_2,
+            pokemon_3,
+            position_pokemon_1,
+            position_pokemon_2,
+            position_pokemon_3,
+        )
+
+        self.assertEqual(positioned_pokemons, [pokemon_2, pokemon_3, pokemon_1])
+
+    def test_position_pokemons_raises_exception_if_duplicated_positions(self):
+        pokemon_1 = mommy.make("pokemons.Pokemon", name="pokemon1")
+        pokemon_2 = mommy.make("pokemons.Pokemon", name="pokemon2")
+        pokemon_3 = mommy.make("pokemons.Pokemon", name="pokemon3")
+
+        position_pokemon_1 = 3
+        position_pokemon_2 = 1
+        position_pokemon_3 = 1
+
+        with self.assertRaises(DuplicatedPokemonPositions):
+            position_pokemons(
+                pokemon_1,
+                pokemon_2,
+                pokemon_3,
+                position_pokemon_1,
+                position_pokemon_2,
+                position_pokemon_3,
+            )

--- a/backend/battles/tests/test_helpers.py
+++ b/backend/battles/tests/test_helpers.py
@@ -126,12 +126,8 @@ class BattleHelperTests(TestCase):
         position_pokemon_3 = 2
 
         positioned_pokemons = position_pokemons(
-            pokemon_1,
-            pokemon_2,
-            pokemon_3,
-            position_pokemon_1,
-            position_pokemon_2,
-            position_pokemon_3,
+            [pokemon_1, pokemon_2, pokemon_3],
+            [position_pokemon_1, position_pokemon_2, position_pokemon_3],
         )
 
         self.assertEqual(positioned_pokemons, [pokemon_2, pokemon_3, pokemon_1])
@@ -147,10 +143,6 @@ class BattleHelperTests(TestCase):
 
         with self.assertRaises(DuplicatedPokemonPositions):
             position_pokemons(
-                pokemon_1,
-                pokemon_2,
-                pokemon_3,
-                position_pokemon_1,
-                position_pokemon_2,
-                position_pokemon_3,
+                [pokemon_1, pokemon_2, pokemon_3],
+                [position_pokemon_1, position_pokemon_2, position_pokemon_3],
             )

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -300,9 +300,6 @@ class BattleUpdateOpponentPokemonsViewTests(TestCase):
             "opponent_pokemon_1": pokemon_3.id,
             "opponent_pokemon_2": pokemon_2.id,
             "opponent_pokemon_3": pokemon_1.id,
-            "position_opponent_pokemon_1": "3",
-            "position_opponent_pokemon_2": "1",
-            "position_opponent_pokemon_3": "2",
         }
 
         self.assertIsNone(battle.opponent_pokemon_1)
@@ -313,16 +310,12 @@ class BattleUpdateOpponentPokemonsViewTests(TestCase):
         response = self.client.post(url, data)
 
         battle = Battle.objects.get(pk=battle.id)
-        self.assertEqual(battle.opponent_pokemon_1.poke_id, 2)
-        self.assertEqual(battle.opponent_pokemon_2.poke_id, 1)
-        self.assertEqual(battle.opponent_pokemon_3.poke_id, 3)
+        self.assertEqual(battle.opponent_pokemon_1.poke_id, 3)
+        self.assertEqual(battle.opponent_pokemon_2.poke_id, 2)
+        self.assertEqual(battle.opponent_pokemon_3.poke_id, 1)
 
         send_mock.assert_called_with(battle)
         self.assertEqual(response.status_code, 302)
-
-        self.assertEqual(battle.opponent_pokemon_1, pokemon_2)
-        self.assertEqual(battle.opponent_pokemon_2, pokemon_1)
-        self.assertEqual(battle.opponent_pokemon_3, pokemon_3)
 
     def test_non_logged_user_cannot_access_add_opponent_pokemons_to_battle(self):
         url = reverse("users:user_logout")

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -162,6 +162,9 @@ class BattleCreateViewTests(TestCase):
             "creator_pokemon_1": pokemon_1.id,
             "creator_pokemon_2": pokemon_2.id,
             "creator_pokemon_3": pokemon_3.id,
+            "position_creator_pokemon_1": "1",
+            "position_creator_pokemon_2": "2",
+            "position_creator_pokemon_3": "3",
         }
         url = reverse("battles:battle_create")
 

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -300,6 +300,9 @@ class BattleUpdateOpponentPokemonsViewTests(TestCase):
             "opponent_pokemon_1": pokemon_3.id,
             "opponent_pokemon_2": pokemon_2.id,
             "opponent_pokemon_3": pokemon_1.id,
+            "position_opponent_pokemon_1": "3",
+            "position_opponent_pokemon_2": "1",
+            "position_opponent_pokemon_3": "2",
         }
 
         self.assertIsNone(battle.opponent_pokemon_1)
@@ -310,12 +313,16 @@ class BattleUpdateOpponentPokemonsViewTests(TestCase):
         response = self.client.post(url, data)
 
         battle = Battle.objects.get(pk=battle.id)
-        self.assertEqual(battle.opponent_pokemon_1.poke_id, 3)
-        self.assertEqual(battle.opponent_pokemon_2.poke_id, 2)
-        self.assertEqual(battle.opponent_pokemon_3.poke_id, 1)
+        self.assertEqual(battle.opponent_pokemon_1.poke_id, 2)
+        self.assertEqual(battle.opponent_pokemon_2.poke_id, 1)
+        self.assertEqual(battle.opponent_pokemon_3.poke_id, 3)
 
         send_mock.assert_called_with(battle)
         self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(battle.opponent_pokemon_1, pokemon_2)
+        self.assertEqual(battle.opponent_pokemon_2, pokemon_1)
+        self.assertEqual(battle.opponent_pokemon_3, pokemon_3)
 
     def test_non_logged_user_cannot_access_add_opponent_pokemons_to_battle(self):
         url = reverse("users:user_logout")


### PR DESCRIPTION
[As a trainer I can choose the position of the PKN in the battle form](https://trello.com/c/GM82K4Zf/18-as-a-trainer-i-can-choose-the-position-of-the-pkn-in-the-battle-form)

### Description
This PRs allows battle creator to choose pokemons position.

### How to test
It's important run the Celery task to get all Pokemons from PokeAPI to test this PR.
- [ ] Go to the page to add a battle
- [ ] Insert Pokemons in the battle
- [ ] Choose the positions and check if Pokemons are positioned in the battle as expected