### PR TITLE
[Partial] Adds endpoint to update battle with opponent's Pokemons

### DIFF
--- a/backend/api/battles/serializers.py
+++ b/backend/api/battles/serializers.py
@@ -101,7 +101,7 @@ class BattleSerializer(serializers.ModelSerializer):
 
         opponent_pokemons = [opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3]
 
-        if not any(pokemon is None for pokemon in opponent_pokemons):
+        if any(pokemon is None for pokemon in opponent_pokemons):
             return
 
         instance.opponent_pokemon_1 = opponent_pokemon_1

--- a/backend/api/battles/serializers.py
+++ b/backend/api/battles/serializers.py
@@ -94,19 +94,6 @@ class BattleSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         return Battle.objects.create(**validated_data)
 
-    def update_opponent_pokemons(
-        self, battle, opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3
-    ):
-        opponent_pokemons = [opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3]
-
-        if any(pokemon is None for pokemon in opponent_pokemons):
-            return
-
-        battle.opponent_pokemon_1 = opponent_pokemon_1
-        battle.opponent_pokemon_2 = opponent_pokemon_2
-        battle.opponent_pokemon_3 = opponent_pokemon_3
-        battle.save()
-
     def update(self, instance, validated_data):
         opponent_pokemon_1 = self.validated_data.pop("opponent_pokemon_1", None)
         opponent_pokemon_2 = self.validated_data.pop("opponent_pokemon_2", None)
@@ -114,8 +101,14 @@ class BattleSerializer(serializers.ModelSerializer):
 
         instance = super().update(instance, validated_data)
 
-        self.update_opponent_pokemons(
-            instance, opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3
-        )
+        opponent_pokemons = [opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3]
+
+        if any(pokemon is None for pokemon in opponent_pokemons):
+            return
+
+        instance.opponent_pokemon_1 = opponent_pokemon_1
+        instance.opponent_pokemon_2 = opponent_pokemon_2
+        instance.opponent_pokemon_3 = opponent_pokemon_3
+        instance.save()
 
         return instance

--- a/backend/api/battles/serializers.py
+++ b/backend/api/battles/serializers.py
@@ -69,10 +69,7 @@ class BattleSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Pokemons' points sum cannot be more than 600")
 
         if self.instance:
-            object_id = self.instance.id
-
-            battle = Battle.objects.get(pk=object_id)
-            if request.user != battle.opponent:
+            if request.user != self.instance.opponent:
                 raise serializers.ValidationError(
                     "You can't update opponent Pokemons if you aren't the battle opponent"
                 )

--- a/backend/api/battles/serializers.py
+++ b/backend/api/battles/serializers.py
@@ -4,8 +4,6 @@ from api.battles.validators import validate_pokemon
 from battles.models import Battle
 from pokemons.exceptions import PokemonNotFound
 from pokemons.helpers import get_pokemons_points_sum
-from pokemons.models import Pokemon
-from pokemons.services import pokemon_exists
 
 
 class BattleSerializer(serializers.ModelSerializer):
@@ -94,16 +92,16 @@ class BattleSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         return Battle.objects.create(**validated_data)
 
-    def update(self, instance, validated_data):
+    def update(self, instance, validated_data):  # noqa
+        instance = super().update(instance, validated_data)
+
         opponent_pokemon_1 = self.validated_data.pop("opponent_pokemon_1", None)
         opponent_pokemon_2 = self.validated_data.pop("opponent_pokemon_2", None)
         opponent_pokemon_3 = self.validated_data.pop("opponent_pokemon_3", None)
 
-        instance = super().update(instance, validated_data)
-
         opponent_pokemons = [opponent_pokemon_1, opponent_pokemon_2, opponent_pokemon_3]
 
-        if any(pokemon is None for pokemon in opponent_pokemons):
+        if not any(pokemon is None for pokemon in opponent_pokemons):
             return
 
         instance.opponent_pokemon_1 = opponent_pokemon_1

--- a/backend/api/battles/serializers.py
+++ b/backend/api/battles/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from api.battles.validators import validate_pokemon
 from battles.models import Battle
 from pokemons.exceptions import PokemonNotFound
 from pokemons.helpers import get_pokemons_points_sum
@@ -31,34 +32,22 @@ class BattleSerializer(serializers.ModelSerializer):
         )
 
     def validate_creator_pokemon_1(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate_creator_pokemon_2(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate_creator_pokemon_3(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate_opponent_pokemon_1(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate_opponent_pokemon_2(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate_opponent_pokemon_3(self, value):
-        if not pokemon_exists(value):
-            raise serializers.ValidationError("Sorry, this pokemon was not found")
-        return Pokemon.objects.get(name=value)
+        return validate_pokemon(value)
 
     def validate(self, attrs):
         request = self.context.get("request")

--- a/backend/api/battles/tests/test_views.py
+++ b/backend/api/battles/tests/test_views.py
@@ -15,7 +15,7 @@ class PublicBattleListCreateEndpointTests(TestCase):
         self.client = APIClient()
 
     def test_login_required(self):
-        url = reverse("api_battles:battles")
+        url = reverse("api_battles:battle_list_create")
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -73,7 +73,7 @@ class PrivateBattleListCreateEndpointTests(TestCase):
             "creator_pokemon_2": pokemon_2.name,
             "creator_pokemon_3": pokemon_3.name,
         }
-        url = reverse("api_battles:battles")
+        url = reverse("api_battles:battle_list_create")
 
         battle = Battle.objects.filter(opponent=opponent).first()
         self.assertIsNone(battle)
@@ -92,7 +92,7 @@ class PrivateBattleListCreateEndpointTests(TestCase):
             "creator": self.user.id,
             "opponent": opponent.id,
         }
-        url = reverse("api_battles:battles")
+        url = reverse("api_battles:battle_list_create")
 
         response = self.client.post(url, data)
 
@@ -113,7 +113,7 @@ class PrivateBattleListCreateEndpointTests(TestCase):
             "creator_pokemon_2": "pokemon2",
             "creator_pokemon_3": "pokemon3",
         }
-        url = reverse("api_battles:battles")
+        url = reverse("api_battles:battle_list_create")
         response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -172,7 +172,7 @@ class PrivateBattleListCreateEndpointTests(TestCase):
             "creator_pokemon_2": pokemon_2.name,
             "creator_pokemon_3": pokemon_3.name,
         }
-        url = reverse("api_battles:battles")
+        url = reverse("api_battles:battle_list_create")
         response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/api/battles/tests/test_views.py
+++ b/backend/api/battles/tests/test_views.py
@@ -506,5 +506,5 @@ class PrivateBattleRetrieveUpdateEndpointTests(TestCase):
         self.assertEqual(
             response.content,
             b'{"non_field_errors":['
-            b'"You can\'t update opponent Pokemons if you aren\'t the battle opponent"]}',
+            b"\"You can't update opponent Pokemons if you aren't the battle opponent\"]}",
         )

--- a/backend/api/battles/tests/test_views.py
+++ b/backend/api/battles/tests/test_views.py
@@ -180,3 +180,330 @@ class PrivateBattleListCreateEndpointTests(TestCase):
             response.content,
             b'{"non_field_errors":["Pokemons\' points sum cannot be more than 600"]}',
         )
+
+
+class PublicBattleRetrieveUpdateEndpointTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_login_required(self):
+        url = reverse("api_battles:battle_retrieve_update", args=[1])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PrivateBattleRetrieveUpdateEndpointTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user("test@test.com", "password123")
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    @responses.activate
+    def test_opponent_select_pokemons(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon1", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon2", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon3", status=200)
+
+        pokemon_1 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=1,
+            name="pokemon1",
+            attack=49,
+            defense=49,
+            hit_points=45,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/1.png",
+        )
+        pokemon_2 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=2,
+            name="pokemon2",
+            attack=64,
+            defense=64,
+            hit_points=50,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/2.png",
+        )
+        pokemon_3 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=3,
+            name="pokemon3",
+            attack=69,
+            defense=69,
+            hit_points=55,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/3.png",
+        )
+
+        battle = mommy.make(
+            "battles.Battle",
+            creator=mommy.make("users.User"),
+            opponent=self.user,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        data = {
+            "creator": battle.creator.id,
+            "opponent": battle.opponent.id,
+            "creator_pokemon_1": battle.creator_pokemon_1,
+            "creator_pokemon_2": battle.creator_pokemon_2,
+            "creator_pokemon_3": battle.creator_pokemon_3,
+            "opponent_pokemon_1": "pokemon3",
+            "opponent_pokemon_2": "pokemon2",
+            "opponent_pokemon_3": "pokemon1",
+        }
+
+        self.assertIsNone(battle.opponent_pokemon_1)
+        self.assertIsNone(battle.opponent_pokemon_2)
+        self.assertIsNone(battle.opponent_pokemon_3)
+
+        url = reverse("api_battles:battle_retrieve_update", args=[battle.id])
+        response = self.client.put(url, data)
+
+        battle = Battle.objects.get(pk=battle.id)
+        self.assertEqual(battle.opponent_pokemon_1.poke_id, 3)
+        self.assertEqual(battle.opponent_pokemon_2.poke_id, 2)
+        self.assertEqual(battle.opponent_pokemon_3.poke_id, 1)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @responses.activate
+    def test_cannot_update_battle_with_unexisting_pokemons(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon1", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon2", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon3", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon4", status=404)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon5", status=404)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon6", status=404)
+
+        pokemon_1 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=1,
+            name="pokemon1",
+            attack=49,
+            defense=49,
+            hit_points=45,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/1.png",
+        )
+        pokemon_2 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=2,
+            name="pokemon2",
+            attack=64,
+            defense=64,
+            hit_points=50,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/2.png",
+        )
+        pokemon_3 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=3,
+            name="pokemon3",
+            attack=69,
+            defense=69,
+            hit_points=55,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/3.png",
+        )
+
+        battle = mommy.make(
+            "battles.Battle",
+            creator=mommy.make("users.User"),
+            opponent=self.user,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        data = {
+            "creator": battle.creator.id,
+            "opponent": battle.opponent.id,
+            "creator_pokemon_1": battle.creator_pokemon_1,
+            "creator_pokemon_2": battle.creator_pokemon_2,
+            "creator_pokemon_3": battle.creator_pokemon_3,
+            "opponent_pokemon_1": "pokemon4",
+            "opponent_pokemon_2": "pokemon5",
+            "opponent_pokemon_3": "pokemon6",
+        }
+
+        url = reverse("api_battles:battle_retrieve_update", args=[battle.id])
+        response = self.client.put(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "opponent_pokemon_1": ["Sorry, this pokemon was not found"],
+                "opponent_pokemon_2": ["Sorry, this pokemon was not found"],
+                "opponent_pokemon_3": ["Sorry, this pokemon was not found"],
+            },
+        )
+
+    @responses.activate
+    def test_cannot_update_battle_if_pokemon_points_sum_is_more_than_600(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon1", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon2", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon3", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon4", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon5", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon6", status=200)
+
+        pokemon_1 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=1,
+            name="pokemon1",
+            attack=49,
+            defense=49,
+            hit_points=45,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/1.png",
+        )
+        pokemon_2 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=2,
+            name="pokemon2",
+            attack=64,
+            defense=64,
+            hit_points=50,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/2.png",
+        )
+        pokemon_3 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=3,
+            name="pokemon3",
+            attack=69,
+            defense=69,
+            hit_points=55,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/3.png",
+        )
+        mommy.make(
+            "pokemons.Pokemon",
+            poke_id=4,
+            name="pokemon4",
+            attack=100,
+            defense=100,
+            hit_points=100,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/4.png",
+        )
+        mommy.make(
+            "pokemons.Pokemon",
+            poke_id=5,
+            name="pokemon5",
+            attack=100,
+            defense=100,
+            hit_points=100,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/5.png",
+        )
+        mommy.make(
+            "pokemons.Pokemon",
+            poke_id=6,
+            name="pokemon6",
+            attack=100,
+            defense=100,
+            hit_points=100,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/6.png",
+        )
+
+        battle = mommy.make(
+            "battles.Battle",
+            creator=mommy.make("users.User"),
+            opponent=self.user,
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        data = {
+            "creator": battle.creator.id,
+            "opponent": battle.opponent.id,
+            "creator_pokemon_1": battle.creator_pokemon_1,
+            "creator_pokemon_2": battle.creator_pokemon_2,
+            "creator_pokemon_3": battle.creator_pokemon_3,
+            "opponent_pokemon_1": "pokemon4",
+            "opponent_pokemon_2": "pokemon5",
+            "opponent_pokemon_3": "pokemon6",
+        }
+
+        url = reverse("api_battles:battle_retrieve_update", args=[battle.id])
+        response = self.client.put(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.content,
+            b'{"non_field_errors":["Pokemons\' points sum cannot be more than 600"]}',
+        )
+
+    @responses.activate
+    def test_cannot_select_opponent_pokemons_if_user_is_not_opponent(self):
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon1", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon2", status=200)
+        responses.add(responses.HEAD, f"{POKEAPI_BASE_URL}pokemon/pokemon3", status=200)
+
+        pokemon_1 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=1,
+            name="pokemon1",
+            attack=49,
+            defense=49,
+            hit_points=45,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/1.png",
+        )
+        pokemon_2 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=2,
+            name="pokemon2",
+            attack=64,
+            defense=64,
+            hit_points=50,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/2.png",
+        )
+        pokemon_3 = mommy.make(
+            "pokemons.Pokemon",
+            poke_id=3,
+            name="pokemon3",
+            attack=69,
+            defense=69,
+            hit_points=55,
+            image="https://raw.githubusercontent.com/"
+            "PokeAPI/sprites/master/sprites/pokemon/3.png",
+        )
+
+        battle = mommy.make(
+            "battles.Battle",
+            creator=mommy.make("users.User"),
+            opponent=mommy.make("users.User"),
+            creator_pokemon_1=pokemon_1,
+            creator_pokemon_2=pokemon_2,
+            creator_pokemon_3=pokemon_3,
+        )
+
+        data = {
+            "creator": battle.creator.id,
+            "opponent": battle.opponent.id,
+            "creator_pokemon_1": battle.creator_pokemon_1,
+            "creator_pokemon_2": battle.creator_pokemon_2,
+            "creator_pokemon_3": battle.creator_pokemon_3,
+            "opponent_pokemon_1": pokemon_3,
+            "opponent_pokemon_2": pokemon_2,
+            "opponent_pokemon_3": pokemon_1,
+        }
+
+        url = reverse("api_battles:battle_retrieve_update", args=[battle.id])
+        response = self.client.put(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.content,
+            b'{"non_field_errors":["You can\'t update opponent Pokemons if you aren\'t the battle opponent"]}',
+        )

--- a/backend/api/battles/tests/test_views.py
+++ b/backend/api/battles/tests/test_views.py
@@ -505,5 +505,6 @@ class PrivateBattleRetrieveUpdateEndpointTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.content,
-            b'{"non_field_errors":["You can\'t update opponent Pokemons if you aren\'t the battle opponent"]}',
+            b'{"non_field_errors":['
+            b'"You can\'t update opponent Pokemons if you aren\'t the battle opponent"]}',
         )

--- a/backend/api/battles/urls.py
+++ b/backend/api/battles/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("", views.BattleListCreateEndpoint.as_view(), name="battle_list_create"),
+    path("<int:pk>", views.BattleRetrieveUpdateEndpoint.as_view(), name="battle_retrieve_update"),
 ]

--- a/backend/api/battles/urls.py
+++ b/backend/api/battles/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.BattleListCreateEndpoint.as_view(), name="battles"),
+    path("", views.BattleListCreateEndpoint.as_view(), name="battle_list_create"),
 ]

--- a/backend/api/battles/validators.py
+++ b/backend/api/battles/validators.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from pokemons.models import Pokemon
+from pokemons.services import pokemon_exists
+
+
+def validate_pokemon(pokemon_name):
+    if not pokemon_exists(pokemon_name):
+        raise serializers.ValidationError("Sorry, this pokemon was not found")
+    return Pokemon.objects.get(name=pokemon_name)

--- a/backend/api/battles/views.py
+++ b/backend/api/battles/views.py
@@ -10,3 +10,9 @@ class BattleListCreateEndpoint(generics.ListCreateAPIView):
     serializer_class = BattleSerializer
     queryset = Battle.objects.all()
     permission_classes = (IsAuthenticated,)
+
+
+class BattleRetrieveUpdateEndpoint(generics.RetrieveUpdateAPIView):
+    serializer_class = BattleSerializer
+    queryset = Battle.objects.all()
+    permission_classes = (IsAuthenticated,)

--- a/backend/pokebattle/urls.py
+++ b/backend/pokebattle/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path("jsreverse/", django_js_reverse.views.urls_js, name="js_reverse"),
     path("oauth/", include("social_django.urls", namespace="social")),
     path("api/users/", include(("api.users.urls", "users"), namespace="api_users")),
-    path("api/battles", include(("api.battles.urls", "battles"), namespace="api_battles")),
+    path("api/battles/", include(("api.battles.urls", "battles"), namespace="api_battles")),
 ]


### PR DESCRIPTION
[As a Programmer I write a RESTful endpoint to server the React Frontend](https://trello.com/c/OpftBl6x/26-as-a-programmer-i-write-a-restful-endpoint-to-server-the-react-frontend)

### Description
This PRs adds the endpoint to create a battle, considering all the validation cases needed.

### How to test
You need to have at least one battle created, where you're the opponent.
- [ ] Access `http://localhost:8000/user/login` and log in the application
- [ ] Create a battle where you're he opponent
- [ ] Go to `http://localhost:8000/api/battles/{id}` and check that you receive the battle data
- [ ] Insert unexisting Pokemons and check that you receive the message "Sorry, this pokemon was not found"
- [ ] Insert Pokemons who points sum is higher than 600 and check that you receive the message "Pokemons' points sum cannot be more than 600". You can use the pokemons: Arceus, Kyurem, and Mewtwo.
- [ ] Select valid Pokemons (according to business rules) and check that it's working as expected
- [ ] Try to update the battle without the opponent account and check that you receive the message "You can't update opponent Pokemons if you aren't the battle opponent"